### PR TITLE
Refactor CLI commands and update dependencies for improved maintainability

### DIFF
--- a/.changeset/bright-parrots-go.md
+++ b/.changeset/bright-parrots-go.md
@@ -1,0 +1,24 @@
+---
+'br-helpers': patch
+---
+
+Refactor CLI commands and update package dependencies
+
+- Refactored the CLI command structure in `bin/br-helpers` to use a more modular approach.
+  - Introduced a `commandDefinitions` object to define commands (cpf, cnpj, cep, phone, identifier)
+  - Each command now has its own `analyze` or `execute` function for processing input.
+  - Removed yargs dependency and replaced it with a custom argument parser.
+  - Improved help rendering for commands and options.
+
+- Updated the version in `package-lock.json` and `package.json` from 3.0.2 to 3.1.2.
+  - Removed yargs from dependencies as it is no longer needed.
+  - Cleaned up unused dependencies from the lock file to reduce bloat.
+
+- Added a new test suite in `src/cli.spec.ts` to ensure CLI functionality:
+  - Tests for global help display.
+  - Tests for CPF command output in JSON format.
+  - Tests for handling invalid CPF input.
+  - Tests for the identifier command output.
+
+These changes enhance the maintainability of the CLI tool and improve user experience by providing
+clearer command definitions and outputs.

--- a/bin/br-helpers
+++ b/bin/br-helpers
@@ -1,249 +1,367 @@
 #!/usr/bin/env node
 /// <reference types="node" />
 
-/** @typedef {import('yargs').Argv<Record<string, unknown>>} CliBuilder */
-/** @typedef {import('yargs').ArgumentsCamelCase<{ value: string, field?: 'valid' | 'digits' | 'formatted', output: 'text' | 'json' }>} CpfCommandArgs */
-/** @typedef {import('yargs').ArgumentsCamelCase<{ value: string, field?: 'valid' | 'value' | 'formatted', output: 'text' | 'json' }>} CnpjCommandArgs */
-/** @typedef {import('yargs').ArgumentsCamelCase<{ value: string, field?: 'valid' | 'normalized' | 'formatted', output: 'text' | 'json' }>} CepCommandArgs */
-/** @typedef {import('yargs').ArgumentsCamelCase<{ value: string, field?: 'valid' | 'digits' | 'formatted', output: 'text' | 'json' }>} PhoneCommandArgs */
-/** @typedef {import('yargs').ArgumentsCamelCase<{ value: string }>} IdentifierCommandArgs */
-
-const yargs = require('yargs');
-const { hideBin } = require('yargs/helpers');
 const api = require('../dist/index.js');
 
-yargs(hideBin(process.argv))
-  .scriptName('br-helpers')
-  .usage('$0 <command> [options]')
-  .command(
-    'cpf <value>',
-    'Valida, formata e analisa CPF',
-    /** @param {CliBuilder} yargs */
-    (yargs) => {
-      yargs
-        .positional('value', {
-          describe: 'CPF para processar',
-          type: 'string',
-        })
-        .option('field', {
-          alias: 'f',
-          describe: 'Campo a retornar: valid, digits, formatted',
-          choices: ['valid', 'digits', 'formatted'],
-          default: undefined,
-        })
-        .option('output', {
-          alias: 'o',
-          describe: 'Formato de saída: text, json',
-          choices: ['text', 'json'],
-          default: 'text',
-        });
+const commandDefinitions = {
+  cpf: {
+    usage: 'cpf <value>',
+    description: 'Valida, formata e analisa CPF',
+    valueDescription: 'CPF para processar',
+    fields: ['valid', 'digits', 'formatted'],
+    supportsOutput: true,
+    analyze(value) {
+      return api.Cpf.parse(value);
     },
-    /** @param {CpfCommandArgs} argv */
-    (argv) => {
-      const { value, field, output } = argv;
-      const result = api.Cpf.parse(value);
-      let chalk;
-      try {
-        chalk = require('chalk');
-      } catch {
-        chalk = null;
-      }
-      const color = (val, ok) => (chalk ? (ok ? chalk.green(val) : chalk.red(val)) : val);
-      if (field) {
-        const val = result[field];
-        if (output === 'json') {
-          console.log(JSON.stringify({ [field]: val }, null, 2));
-        } else {
-          console.log(val);
-        }
-      } else if (output === 'json') {
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        console.log(`${chalk ? chalk.bold('Válido:') : 'Válido:'} ${color(result.valid, result.valid)}`);
-        console.log(`${chalk ? chalk.bold('Normalizado:') : 'Normalizado:'} ${result.digits}`);
-        console.log(`${chalk ? chalk.bold('Formatado:') : 'Formatado:'} ${result.formatted}`);
-      }
-      process.exit(result.valid ? 0 : 2);
+    normalizedKey: 'digits',
+  },
+  cnpj: {
+    usage: 'cnpj <value>',
+    description: 'Valida, formata e analisa CNPJ',
+    valueDescription: 'CNPJ para processar',
+    fields: ['valid', 'value', 'formatted'],
+    supportsOutput: true,
+    analyze(value) {
+      return api.Cnpj.parse(value);
     },
-  )
-  .command(
-    'cnpj <value>',
-    'Valida, formata e analisa CNPJ',
-    /** @param {CliBuilder} yargs */
-    (yargs) => {
-      yargs
-        .positional('value', {
-          describe: 'CNPJ para processar',
-          type: 'string',
-        })
-        .option('field', {
-          alias: 'f',
-          describe: 'Campo a retornar: valid, value, formatted',
-          choices: ['valid', 'value', 'formatted'],
-          default: undefined,
-        })
-        .option('output', {
-          alias: 'o',
-          describe: 'Formato de saída: text, json',
-          choices: ['text', 'json'],
-          default: 'text',
-        });
+    normalizedKey: 'value',
+  },
+  cep: {
+    usage: 'cep <value>',
+    description: 'Valida e formata CEP',
+    valueDescription: 'CEP para processar',
+    fields: ['valid', 'normalized', 'formatted'],
+    supportsOutput: true,
+    analyze(value) {
+      return {
+        valid: api.Cep.isValid(value),
+        normalized: api.NumericIdentifier.from(value).value,
+        formatted: api.Cep.format(value),
+      };
     },
-    /** @param {CnpjCommandArgs} argv */
-    (argv) => {
-      const { value, field, output } = argv;
-      const result = api.Cnpj.parse(value);
-      let chalk;
-      try {
-        chalk = require('chalk');
-      } catch {
-        chalk = null;
-      }
-      const color = (val, ok) => (chalk ? (ok ? chalk.green(val) : chalk.red(val)) : val);
-      if (field) {
-        const val = result[field];
-        if (output === 'json') {
-          console.log(JSON.stringify({ [field]: val }, null, 2));
-        } else {
-          console.log(val);
-        }
-      } else if (output === 'json') {
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        console.log(`${chalk ? chalk.bold('Válido:') : 'Válido:'} ${color(result.valid, result.valid)}`);
-        console.log(`${chalk ? chalk.bold('Normalizado:') : 'Normalizado:'} ${result.value}`);
-        console.log(`${chalk ? chalk.bold('Formatado:') : 'Formatado:'} ${result.formatted}`);
-      }
-      process.exit(result.valid ? 0 : 2);
+    normalizedKey: 'normalized',
+  },
+  phone: {
+    usage: 'phone <value>',
+    description: 'Valida, formata e analisa telefone',
+    valueDescription: 'Telefone para processar',
+    fields: ['valid', 'digits', 'formatted'],
+    supportsOutput: true,
+    analyze(value) {
+      return api.Phone.parse(value);
     },
-  )
-  .command(
-    'cep <value>',
-    'Valida e formata CEP',
-    /** @param {CliBuilder} yargs */
-    (yargs) => {
-      yargs
-        .positional('value', {
-          describe: 'CEP para processar',
-          type: 'string',
-        })
-        .option('field', {
-          alias: 'f',
-          describe: 'Campo a retornar: valid, normalized, formatted',
-          choices: ['valid', 'normalized', 'formatted'],
-          default: undefined,
-        })
-        .option('output', {
-          alias: 'o',
-          describe: 'Formato de saída: text, json',
-          choices: ['text', 'json'],
-          default: 'text',
-        });
-    },
-    /** @param {CepCommandArgs} argv */
-    (argv) => {
-      const { value, field, output } = argv;
-      const valid = api.Cep.isValid(value);
-      const formatted = api.Cep.format(value);
-      const normalized = api.NumericIdentifier.from(value).value;
-      let chalk;
-      try {
-        chalk = require('chalk');
-      } catch {
-        chalk = null;
-      }
-      const color = (val, ok) => (chalk ? (ok ? chalk.green(val) : chalk.red(val)) : val);
-      if (field) {
-        let val;
-        if (field === 'valid') val = valid;
-        else if (field === 'normalized') val = normalized;
-        else if (field === 'formatted') val = formatted;
-        if (output === 'json') {
-          console.log(JSON.stringify({ [field]: val }, null, 2));
-        } else {
-          console.log(val);
-        }
-      } else if (output === 'json') {
-        console.log(JSON.stringify({ valid, normalized, formatted }, null, 2));
-      } else {
-        console.log(`${chalk ? chalk.bold('Válido:') : 'Válido:'} ${color(valid, valid)}`);
-        console.log(`${chalk ? chalk.bold('Normalizado:') : 'Normalizado:'} ${normalized}`);
-        console.log(`${chalk ? chalk.bold('Formatado:') : 'Formatado:'} ${formatted}`);
-      }
-      process.exit(valid ? 0 : 2);
-    },
-  )
-  .command(
-    'phone <value>',
-    'Valida, formata e analisa telefone',
-    /** @param {CliBuilder} yargs */
-    (yargs) => {
-      yargs
-        .positional('value', {
-          describe: 'Telefone para processar',
-          type: 'string',
-        })
-        .option('field', {
-          alias: 'f',
-          describe: 'Campo a retornar: valid, digits, formatted',
-          choices: ['valid', 'digits', 'formatted'],
-          default: undefined,
-        })
-        .option('output', {
-          alias: 'o',
-          describe: 'Formato de saída: text, json',
-          choices: ['text', 'json'],
-          default: 'text',
-        });
-    },
-    /** @param {PhoneCommandArgs} argv */
-    (argv) => {
-      const { value, field, output } = argv;
-      const result = api.Phone.parse(value);
-      let chalk;
-      try {
-        chalk = require('chalk');
-      } catch {
-        chalk = null;
-      }
-      const color = (val, ok) => (chalk ? (ok ? chalk.green(val) : chalk.red(val)) : val);
-      if (field) {
-        const val = result[field];
-        if (output === 'json') {
-          console.log(JSON.stringify({ [field]: val }, null, 2));
-        } else {
-          console.log(val);
-        }
-      } else if (output === 'json') {
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        console.log(`${chalk ? chalk.bold('Válido:') : 'Válido:'} ${color(result.valid, result.valid)}`);
-        console.log(`${chalk ? chalk.bold('Normalizado:') : 'Normalizado:'} ${result.digits}`);
-        console.log(`${chalk ? chalk.bold('Formatado:') : 'Formatado:'} ${result.formatted}`);
-      }
-      process.exit(result.valid ? 0 : 2);
-    },
-  )
-  .command(
-    'identifier <value>',
-    'Normaliza identificador numérico ou alfanumérico',
-    /** @param {CliBuilder} yargs */
-    (yargs) => {
-      yargs.positional('value', {
-        describe: 'Identificador para normalizar',
-        type: 'string',
-      });
-    },
-    /** @param {IdentifierCommandArgs} argv */
-    (argv) => {
-      const { value } = argv;
+    normalizedKey: 'digits',
+  },
+  identifier: {
+    usage: 'identifier <value>',
+    description: 'Normaliza identificador numerico ou alfanumerico',
+    valueDescription: 'Identificador para normalizar',
+    fields: [],
+    supportsOutput: false,
+    execute(value) {
       const numeric = api.NumericIdentifier.from(value);
       const alphanumeric = api.AlphanumericIdentifier.from(value);
       console.log(JSON.stringify({ numeric: numeric.value, alphanumeric: alphanumeric.value }, null, 2));
-      process.exit(0);
+      return 0;
     },
-  )
-  .demandCommand(1, 'É necessário informar um comando.')
-  .help()
-  .alias('h', 'help')
-  .strict().argv;
+  },
+};
+
+const commandNames = Object.keys(commandDefinitions);
+const helpAliases = new Set(['-h', '--help']);
+const shortOptionNames = {
+  f: 'field',
+  o: 'output',
+};
+
+function loadChalk() {
+  try {
+    return require('chalk');
+  } catch {
+    return null;
+  }
+}
+
+function makeStyleHelpers() {
+  const chalk = loadChalk();
+
+  return {
+    bold(value) {
+      return chalk ? chalk.bold(value) : value;
+    },
+    color(value, valid) {
+      return chalk ? (valid ? chalk.green(value) : chalk.red(value)) : value;
+    },
+  };
+}
+
+function renderGlobalHelp() {
+  const lines = ['br-helpers <command> [options]', '', 'Commands:'];
+
+  for (const commandName of commandNames) {
+    const definition = commandDefinitions[commandName];
+    lines.push(`  ${definition.usage.padEnd(20)} ${definition.description}`);
+  }
+
+  lines.push('', 'Run "br-helpers <command> --help" for command options.', '', 'Options:', '  -h, --help          Mostra a ajuda');
+
+  return lines.join('\n');
+}
+
+function renderCommandHelp(commandName) {
+  const definition = commandDefinitions[commandName];
+  const lines = [
+    `Uso: br-helpers ${definition.usage} [options]`,
+    '',
+    definition.description,
+    '',
+    'Argumentos:',
+    `  value               ${definition.valueDescription}`,
+  ];
+
+  if (definition.fields.length > 0 || definition.supportsOutput) {
+    lines.push('', 'Opcoes:');
+
+    if (definition.fields.length > 0) {
+      lines.push(`  -f, --field <field>  Campo a retornar: ${definition.fields.join(', ')}`);
+    }
+
+    if (definition.supportsOutput) {
+      lines.push('  -o, --output <fmt>   Formato de saida: text, json');
+    }
+
+    lines.push('  -h, --help           Mostra a ajuda');
+  } else {
+    lines.push('', 'Opcoes:', '  -h, --help           Mostra a ajuda');
+  }
+
+  return lines.join('\n');
+}
+
+function fail(message, helpText) {
+  console.error(message);
+  if (helpText) {
+    console.error('');
+    console.error(helpText);
+  }
+  return 1;
+}
+
+function parseOptionToken(token, args, index) {
+  if (token.startsWith('--')) {
+    const equalsIndex = token.indexOf('=');
+    const optionName = equalsIndex === -1 ? token.slice(2) : token.slice(2, equalsIndex);
+    const inlineValue = equalsIndex === -1 ? undefined : token.slice(equalsIndex + 1);
+
+    if (!optionName) {
+      throw new Error(`Opcao invalida: ${token}`);
+    }
+
+    if (inlineValue !== undefined) {
+      return {
+        name: optionName,
+        value: inlineValue,
+        nextIndex: index,
+      };
+    }
+
+    const nextValue = args[index + 1];
+    if (nextValue === undefined || nextValue.startsWith('-')) {
+      throw new Error(`A opcao --${optionName} requer um valor.`);
+    }
+
+    return {
+      name: optionName,
+      value: nextValue,
+      nextIndex: index + 1,
+    };
+  }
+
+  if (token.startsWith('-')) {
+    const equalsIndex = token.indexOf('=');
+    const rawName = equalsIndex === -1 ? token.slice(1) : token.slice(1, equalsIndex);
+    const inlineValue = equalsIndex === -1 ? undefined : token.slice(equalsIndex + 1);
+
+    if (!rawName || rawName.length !== 1) {
+      throw new Error(`Opcao invalida: ${token}`);
+    }
+
+    const mappedName = shortOptionNames[rawName];
+    if (!mappedName) {
+      throw new Error(`Opcao desconhecida: ${token}`);
+    }
+
+    if (inlineValue !== undefined) {
+      return {
+        name: mappedName,
+        value: inlineValue,
+        nextIndex: index,
+      };
+    }
+
+    const nextValue = args[index + 1];
+    if (nextValue === undefined || nextValue.startsWith('-')) {
+      throw new Error(`A opcao -${rawName} requer um valor.`);
+    }
+
+    return {
+      name: mappedName,
+      value: nextValue,
+      nextIndex: index + 1,
+    };
+  }
+
+  throw new Error(`Opcao invalida: ${token}`);
+}
+
+function parseCommandArguments(commandName, rawArgs) {
+  const definition = commandDefinitions[commandName];
+  const positionals = [];
+  const parsedOptions = {
+    field: undefined,
+    output: definition.supportsOutput ? 'text' : undefined,
+    help: false,
+  };
+
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const token = rawArgs[index];
+
+    if (helpAliases.has(token)) {
+      parsedOptions.help = true;
+      continue;
+    }
+
+    if (token === '--') {
+      positionals.push(...rawArgs.slice(index + 1));
+      break;
+    }
+
+    if (token.startsWith('-')) {
+      const parsedOption = parseOptionToken(token, rawArgs, index);
+      index = parsedOption.nextIndex;
+
+      if (parsedOption.name === 'field') {
+        if (definition.fields.length === 0) {
+          throw new Error(`A opcao --field nao esta disponivel para o comando "${commandName}".`);
+        }
+
+        if (!definition.fields.includes(parsedOption.value)) {
+          throw new Error(
+            `Valor invalido para --field: ${parsedOption.value}. Use um destes: ${definition.fields.join(', ')}.`,
+          );
+        }
+
+        parsedOptions.field = parsedOption.value;
+        continue;
+      }
+
+      if (parsedOption.name === 'output') {
+        if (!definition.supportsOutput) {
+          throw new Error(`A opcao --output nao esta disponivel para o comando "${commandName}".`);
+        }
+
+        if (!['text', 'json'].includes(parsedOption.value)) {
+          throw new Error(`Valor invalido para --output: ${parsedOption.value}. Use "text" ou "json".`);
+        }
+
+        parsedOptions.output = parsedOption.value;
+        continue;
+      }
+
+      throw new Error(`Opcao desconhecida: ${token}`);
+    }
+
+    positionals.push(token);
+  }
+
+  if (parsedOptions.help) {
+    return parsedOptions;
+  }
+
+  if (positionals.length === 0) {
+    throw new Error('E necessario informar o valor do comando.');
+  }
+
+  if (positionals.length > 1) {
+    throw new Error(`Argumento inesperado: ${positionals[1]}`);
+  }
+
+  return {
+    ...parsedOptions,
+    value: positionals[0],
+  };
+}
+
+function printFieldValue(field, value, output) {
+  if (output === 'json') {
+    console.log(JSON.stringify({ [field]: value }, null, 2));
+    return;
+  }
+
+  console.log(value);
+}
+
+function printAnalysisSummary(result, normalizedKey) {
+  const styles = makeStyleHelpers();
+
+  console.log(`${styles.bold('Valido:')} ${styles.color(result.valid, result.valid)}`);
+  console.log(`${styles.bold('Normalizado:')} ${result[normalizedKey]}`);
+  console.log(`${styles.bold('Formatado:')} ${result.formatted}`);
+}
+
+function executeAnalysisCommand(commandName, parsedArguments) {
+  const definition = commandDefinitions[commandName];
+  const result = definition.analyze(parsedArguments.value);
+
+  if (parsedArguments.field) {
+    printFieldValue(parsedArguments.field, result[parsedArguments.field], parsedArguments.output);
+  } else if (parsedArguments.output === 'json') {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    printAnalysisSummary(result, definition.normalizedKey);
+  }
+
+  return result.valid ? 0 : 2;
+}
+
+function runCommand(commandName, rawArgs) {
+  const parsedArguments = parseCommandArguments(commandName, rawArgs);
+
+  if (parsedArguments.help) {
+    console.log(renderCommandHelp(commandName));
+    return 0;
+  }
+
+  const definition = commandDefinitions[commandName];
+
+  if (typeof definition.execute === 'function') {
+    return definition.execute(parsedArguments.value);
+  }
+
+  return executeAnalysisCommand(commandName, parsedArguments);
+}
+
+function main(argv) {
+  if (argv.length === 0) {
+    return fail('E necessario informar um comando.', renderGlobalHelp());
+  }
+
+  const [commandName, ...commandArguments] = argv;
+
+  if (helpAliases.has(commandName)) {
+    console.log(renderGlobalHelp());
+    return 0;
+  }
+
+  if (!commandDefinitions[commandName]) {
+    return fail(`Comando desconhecido: ${commandName}`, renderGlobalHelp());
+  }
+
+  try {
+    return runCommand(commandName, commandArguments);
+  } catch (error) {
+    return fail(error.message, renderCommandHelp(commandName));
+  }
+}
+
+process.exitCode = main(process.argv.slice(2));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "br-helpers",
-  "version": "3.0.2",
+  "version": "3.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "br-helpers",
-      "version": "3.0.2",
+      "version": "3.1.2",
       "license": "MIT",
-      "dependencies": {
-        "yargs": "^18.0.0"
-      },
       "bin": {
         "br-helpers": "bin/br-helpers"
       },
@@ -2012,30 +2009,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2148,20 +2121,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2241,12 +2200,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "license": "MIT"
     },
     "node_modules/enquirer": {
       "version": "2.4.1",
@@ -2332,15 +2285,6 @@
         "@esbuild/win32-arm64": "0.27.4",
         "@esbuild/win32-ia32": "0.27.4",
         "@esbuild/win32-x64": "0.27.4"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2807,27 +2751,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "license": "ISC",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/glob-parent": {
@@ -4137,38 +4060,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -4553,58 +4444,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^9.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "license": "ISC",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yocto-queue": {
@@ -5809,16 +5648,6 @@
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true
     },
-    "ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="
-    },
-    "ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="
-    },
     "argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -5901,16 +5730,6 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true
     },
-    "cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "requires": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      }
-    },
     "convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -5963,11 +5782,6 @@
       "requires": {
         "path-type": "^4.0.0"
       }
-    },
-    "emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
     },
     "enquirer": {
       "version": "2.4.1",
@@ -6035,11 +5849,6 @@
         "@esbuild/win32-ia32": "0.27.4",
         "@esbuild/win32-x64": "0.27.4"
       }
-    },
-    "escalade": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="
     },
     "escape-string-regexp": {
       "version": "4.0.0",
@@ -6335,16 +6144,6 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "optional": true
-    },
-    "get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-    },
-    "get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="
     },
     "glob-parent": {
       "version": "6.0.2",
@@ -7119,24 +6918,6 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true
     },
-    "string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "requires": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      }
-    },
-    "strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "requires": {
-        "ansi-regex": "^6.2.2"
-      }
-    },
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -7319,39 +7100,6 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true
-    },
-    "wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "requires": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      }
-    },
-    "y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-    },
-    "yargs": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-      "requires": {
-        "cliui": "^9.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "string-width": "^7.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
-      }
-    },
-    "yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -131,8 +131,5 @@
     "tslib": "^2.8.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.0"
-  },
-  "dependencies": {
-    "yargs": "^18.0.0"
   }
 }

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -1,7 +1,26 @@
+import { existsSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { resolve } from 'node:path';
 
+const rootDir = resolve(__dirname, '..');
 const cliPath = resolve(__dirname, '..', 'bin', 'br-helpers');
+const distEntryPath = resolve(__dirname, '..', 'dist', 'index.js');
+
+function ensureCliBuild() {
+  if (existsSync(distEntryPath)) {
+    return;
+  }
+
+  const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const result = spawnSync(npmCommand, ['run', 'build'], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`Failed to build CLI for tests.\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`);
+  }
+}
 
 function runCli(args: string[]) {
   return spawnSync(process.execPath, [cliPath, ...args], {
@@ -10,6 +29,10 @@ function runCli(args: string[]) {
 }
 
 describe('CLI', () => {
+  beforeAll(() => {
+    ensureCliBuild();
+  }, 30_000);
+
   it('Should show global help', () => {
     const result = runCli(['--help']);
 

--- a/src/cli.spec.ts
+++ b/src/cli.spec.ts
@@ -1,0 +1,42 @@
+import { spawnSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const cliPath = resolve(__dirname, '..', 'bin', 'br-helpers');
+
+function runCli(args: string[]) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    encoding: 'utf8',
+  });
+}
+
+describe('CLI', () => {
+  it('Should show global help', () => {
+    const result = runCli(['--help']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('br-helpers <command> [options]');
+    expect(result.stdout).toContain('cpf <value>');
+    expect(result.stdout).toContain('identifier <value>');
+  });
+
+  it('Should support cpf field output as json', () => {
+    const result = runCli(['cpf', '13768663663', '--field', 'digits', '--output', 'json']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('{\n  "digits": "13768663663"\n}\n');
+  });
+
+  it('Should return exit code 2 for invalid cpf', () => {
+    const result = runCli(['cpf', '00000000000']);
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toContain('Valido: false');
+  });
+
+  it('Should support identifier command', () => {
+    const result = runCli(['identifier', 'CPF: 137.686.636-63']);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe('{\n  "numeric": "13768663663",\n  "alphanumeric": "CPF13768663663"\n}\n');
+  });
+});


### PR DESCRIPTION
- Refactored the CLI command structure in `bin/br-helpers` to use a more modular approach.
  - Introduced a `commandDefinitions` object to define commands (cpf, cnpj, cep, phone, identifier)
  - Each command now has its own `analyze` or `execute` function for processing input.
  - Removed yargs dependency and replaced it with a custom argument parser.
  - Improved help rendering for commands and options.

- Updated the version in `package-lock.json` and `package.json` from 3.0.2 to 3.1.2.
  - Removed yargs from dependencies as it is no longer needed.
  - Cleaned up unused dependencies from the lock file to reduce bloat.

- Added a new test suite in `src/cli.spec.ts` to ensure CLI functionality:
  - Tests for global help display.
  - Tests for CPF command output in JSON format.
  - Tests for handling invalid CPF input.
  - Tests for the identifier command output.

These changes enhance the maintainability of the CLI tool and improve user experience by providing clearer command definitions and outputs.