### PR TITLE
fix: update formatMask properties to readonly in Cep and Phone classes

### DIFF
--- a/.changeset/quick-chefs-fold.md
+++ b/.changeset/quick-chefs-fold.md
@@ -1,0 +1,10 @@
+---
+'br-helpers': patch
+---
+
+Update formatMask properties to readonly in Cep and Phone classes
+
+- Changed #formatMask in Cep class to readonly for better encapsulation.
+- Updated #mobileMaskSlots and #landlineMaskSlots in Phone class to readonly
+  to ensure they are not modified after initialization.
+- Adjusted import order in Phone class for consistency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "br-helpers",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "br-helpers",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "bin": {
         "br-helpers": "bin/br-helpers"

--- a/src/cep.ts
+++ b/src/cep.ts
@@ -1,6 +1,6 @@
 import { NumericIdentifier } from './identifiers';
 export class Cep {
-  static #formatMask: ReadonlyArray<[number, string]> = [[5, '-']];
+  static readonly #formatMask: ReadonlyArray<[number, string]> = [[5, '-']];
 
   static isValid(cep: string): boolean {
     const hasValue = !!cep || typeof cep === 'string';

--- a/src/phone.ts
+++ b/src/phone.ts
@@ -1,5 +1,5 @@
-import { NumericIdentifier } from './identifiers';
 import type { MaskSlot } from './identifiers';
+import { NumericIdentifier } from './identifiers';
 
 export type PhoneKind = 'mobile' | 'landline';
 
@@ -17,12 +17,12 @@ export class Phone {
     11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 22, 24, 27, 28, 31, 32, 33, 34, 35, 37, 38, 41, 42, 43, 44, 45, 46, 47, 48, 49, 51, 53, 54, 55,
     61, 62, 63, 64, 65, 66, 67, 68, 69, 71, 73, 74, 75, 77, 79, 81, 82, 83, 84, 85, 86, 87, 88, 89, 91, 92, 93, 94, 95, 96, 97, 98, 99,
   ]);
-  static #mobileMaskSlots: ReadonlyArray<MaskSlot> = [
+  static readonly #mobileMaskSlots: ReadonlyArray<MaskSlot> = [
     [0, '('],
     [2, ') '],
     [7, '-'],
   ];
-  static #landlineMaskSlots: ReadonlyArray<MaskSlot> = [
+  static readonly #landlineMaskSlots: ReadonlyArray<MaskSlot> = [
     [0, '('],
     [2, ') '],
     [6, '-'],


### PR DESCRIPTION
- Changed #formatMask in Cep class to readonly for better encapsulation.
- Updated #mobileMaskSlots and #landlineMaskSlots in Phone class to readonly to ensure they are not modified after initialization.
- Adjusted import order in Phone class for consistency.